### PR TITLE
add option for pre-existing bittensor keys/install

### DIFF
--- a/validator/INSTALLATION.md
+++ b/validator/INSTALLATION.md
@@ -54,6 +54,7 @@
     ```ini
     WALLET_NAME=validator
     WALLET_HOTKEY=default
+    BITTENSOR_VOLUME_PATH=~/.bittensor
     ```
   - **Start Validator**
     ```
@@ -65,7 +66,7 @@
     ```
     
 - **Configure Validator Hotkey**
-
+  If you don't already have validator keys configured in the default bittensor directory, or in the overridden $BITTENSOR_VOLUME_PATH set in .env, then you can create one using the ready docker with the below commands 
   ```
   docker-compose -f docker-compose.yml -up -d
   docker exec -it validator_btcli_1 bash

--- a/validator/INSTALLATION.md
+++ b/validator/INSTALLATION.md
@@ -66,6 +66,7 @@
     ```
     
 - **Configure Validator Hotkey**
+  
   If you don't already have validator keys configured in the default bittensor directory, or in the overridden $BITTENSOR_VOLUME_PATH set in .env, then you can create one using the ready docker with the below commands 
   ```
   docker-compose -f docker-compose.yml -up -d

--- a/validator/docker-compose.yml
+++ b/validator/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - BITCOIN_NODE_RPC_URL=${BITCOIN_NODE_RPC_URL}
       - BITCOIN_CHEAT_FACTOR_SAMPLE_SIZE=${BITCOIN_CHEAT_FACTOR_SAMPLE_SIZE:-256}
     volumes:
-      - bittensor:/root/.bittensor
+      - ${BITTENSOR_VOLUME_PATH:-/bittensor}:/root/.bittensor
       - miner_db:/data
     depends_on:
       - btcli
@@ -22,7 +22,7 @@ services:
     image: ghcr.io/blockchain-insights/blockchain_insights_base:${VERSION-latest}
     command: [ "tail", "-f", "/dev/null" ]
     volumes:
-      - bittensor:/root/.bittensor
+      - ${BITTENSOR_VOLUME_PATH:-/bittensor}:/root/.bittensor
     restart: unless-stopped
 
   dozzle:


### PR DESCRIPTION
added a environment variable read into the volumes section, this will allow users to override the key directory to where they may have already generated them. 