### PR TITLE
Remove Memgraph query timeout

### DIFF
--- a/miners/bitcoin-funds-flow/docker-compose.yml
+++ b/miners/bitcoin-funds-flow/docker-compose.yml
@@ -112,7 +112,7 @@ services:
     environment:
       - MEMGRAPH_USER=${GRAPH_DB_USER}
       - MEMGRAPH_PASSWORD=${GRAPH_DB_PASSWORD}
-      - MEMGRAPH=--storage-mode ${GRAPH_DB_STORAGE_MODE:-IN_MEMORY_TRANSACTIONAL} --storage-parallel-schema-recovery=true --storage-recovery-thread-count=120  --storage-gc-cycle-sec=300 --log-level=TRACE --also-log-to-stderr --storage-snapshot-on-exit=false --storage-snapshot-interval-sec=14400 --storage-snapshot-retention-count=2 --storage-wal-enabled=false --isolation-level=READ_COMMITTED --replication-restore-state-on-startup=true
+      - MEMGRAPH=--storage-mode ${GRAPH_DB_STORAGE_MODE:-IN_MEMORY_TRANSACTIONAL} --storage-parallel-schema-recovery=true --storage-recovery-thread-count=120  --storage-gc-cycle-sec=300 --log-level=TRACE --also-log-to-stderr --storage-snapshot-on-exit=false --storage-snapshot-interval-sec=14400 --storage-snapshot-retention-count=2 --storage-wal-enabled=false --isolation-level=READ_COMMITTED --replication-restore-state-on-startup=true --query-execution-timeout-sec=0
     volumes:
       - memgraph-data:/var/lib/memgraph
     restart: unless-stopped


### PR DESCRIPTION
For querying large datasets, the default 3 minutes is not enough, so I am removing it.