### PR TITLE
Update README.md - Removed Server Hosting Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ For each server, you'll need to install:
 Consider these providers for server hosting:
 - [Contabo](https://contabo.com/en/dedicated-servers/)
 - [Hetzner](https://www.hetzner.com/dedicated-rootserver/matrix-ax)
-- [Keyhost](https://www.keyhost.com/)
 
 ## Updating Container Images
 To update container images:


### PR DESCRIPTION
Removed the Keyhost Server Hosting Option. Keyhost domain is for sale and it no longer providing server hosting.