### PR TITLE
Documentation and Docker-compose for Loki Pluging

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ docker run hello-world
 
 ### Install Docker Loki Plugin
 
-To improve the subnet you can send telemery and logs accessible only to the subnet 15 team by installing the Docker Loki Pluging. We don't collect sensible information like usersname or passwords. By monitoring the subnet efficiency and errors we can be pro-active by detecting issues promptly.
+To improve the subnet you can send telemery and logs accessible only to the subnet 15 team by installing the Docker Loki Pluging. By monitoring the subnet efficiency and errors we can be pro-active by detecting issues promptly.
 
-Reference: [Grafana Loki Plugin Documentation](https://grafana.com/docs/loki/latest/send-data/docker-driver/)
+> [!NOTE] We don't collect sensible information like usersname or passwords.
+
+> Documentation Reference: [Grafana Loki Plugin Documentation](https://grafana.com/docs/loki/latest/send-data/docker-driver/)
 
 1. Docker command to install Plugin
 
@@ -99,7 +101,7 @@ docker plugin disable loki --force
 docker plugin upgrade loki grafana/loki-docker-driver:2.9.8 --grant-all-permissions
 docker plugin enable loki
 ```
->[!WARNING] To take effect you need to restart the Docker daemon, this will shutdown all services and restart them we suggest to do this only when there is a scheduled upgrade and the registration are disabled not to be affected by the down time scoring.
+>[!WARNING] To take effect you need to restart the Docker daemon, this will shutdown all services and restart them we suggest to do this only when there is a scheduled upgrade and the registrations are disabled not to be affected by the uptime time scoring.
 
 ```bash
 sudo systemctl restart docker

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ ID                  NAME         DESCRIPTION           ENABLED
 ac720b8fcfdb        loki         Loki Logging Driver   true
 ```
 
->[!WARNING] To take effect you need to restart the Docker daemon, this will shutdown all docker copose services and restart them.
+>[!WARNING] To take effect you need to restart the Docker daemon, this will shutdown all docker compose services and restart them.
 
 ```bash
 sudo systemctl restart docker
@@ -90,7 +90,7 @@ sudo systemctl restart docker
    
 ### Docker Loki Plugin UPGRADE Procedure
 
-- When a new version of the plugin driver is availalbe you can use theses commands to upgrade the driver
+- When a new version of the plugin driver is available you can use theses commands to upgrade the driver
 >[!NOTE] Change the version number for the latest, use version number ie: 2.9.10 
 > DO NOT USE `main` is a development branch
 >
@@ -101,7 +101,7 @@ docker plugin disable loki --force
 docker plugin upgrade loki grafana/loki-docker-driver:2.9.8 --grant-all-permissions
 docker plugin enable loki
 ```
->[!WARNING] To take effect you need to restart the Docker daemon, this will shutdown all services and restart them we suggest to do this only when there is a scheduled upgrade and the registrations are disabled not to be affected by the uptime time scoring.
+> [!WARNING] To take effect you need to restart the Docker daemon, this will terminate all services and restart them. We suggest to do this only when there is a scheduled upgrade and the registrations is disabled not to be affected by the uptime time scoring.
 
 ```bash
 sudo systemctl restart docker

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@
 Welcome to the Blockchain Data Subnet Operations repository. This repository hosts Docker configurations and scripts for running a variety of blockchain nodes, indexers, subnet miners and validators.
 
 ## Table of Contents
-- [Introduction](#introduction)
-- [System Prerequisites](#system-prerequisites)
-- [Installation Guides](#installation-guides) 
-- [Server Hosting Options](#server-hosting-options)
-- [Updating Container Images](#updating-container-images)
+- [Blockchain Data Subnet Operations](#blockchain-data-subnet-operations)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [System Prerequisites](#system-prerequisites)
+    - [Install Docker Loki Plugin](#install-docker-loki-plugin)
+    - [Docker Loki Plugin UPGRADE Procedure](#docker-loki-plugin-upgrade-procedure)
+  - [Bittensor and wallet creation](#bittensor-and-wallet-creation)
+  - [Installation Guides](#installation-guides)
 
 
 ## Introduction
@@ -52,6 +55,57 @@ newgrp docker
 ```bash
 docker run hello-world
 ```
+
+### Install Docker Loki Plugin
+
+To improve the subnet you can send telemery and logs accessible only to the subnet 15 team by installing the Docker Loki Pluging. We don't collect sensible information like usersname or passwords. By monitoring the subnet efficiency and errors we can be pro-active by detecting issues promptly.
+
+Reference: [Grafana Loki Plugin Documentation](https://grafana.com/docs/loki/latest/send-data/docker-driver/)
+
+1. Docker command to install Plugin
+
+```bash
+docker plugin install grafana/loki-docker-driver:2.9.8 --alias loki --grant-all-permissions
+```
+
+2. Verify that the Docker Plugin is installed
+
+```bash
+docker plugin ls
+```
+
+Expected output:
+```
+ID                  NAME         DESCRIPTION           ENABLED
+ac720b8fcfdb        loki         Loki Logging Driver   true
+```
+
+>[!WARNING] To take effect you need to restart the Docker daemon, this will shutdown all docker copose services and restart them.
+
+```bash
+sudo systemctl restart docker
+```
+   
+### Docker Loki Plugin UPGRADE Procedure
+
+- When a new version of the plugin driver is availalbe you can use theses commands to upgrade the driver
+>[!NOTE] Change the version number for the latest, use version number ie: 2.9.10 
+> DO NOT USE `main` is a development branch
+>
+>See the latest version on [Docker Hub Loki Pluging Repository](https://hub.docker.com/r/grafana/loki-docker-driver/tags)
+
+```bash
+docker plugin disable loki --force
+docker plugin upgrade loki grafana/loki-docker-driver:2.9.8 --grant-all-permissions
+docker plugin enable loki
+```
+>[!WARNING] To take effect you need to restart the Docker daemon, this will shutdown all services and restart them we suggest to do this only when there is a scheduled upgrade and the registration are disabled not to be affected by the down time scoring.
+
+```bash
+sudo systemctl restart docker
+```
+
+---
 
 ## Bittensor and wallet creation
 You will also need to [install Bittensor](https://docs.bittensor.com/getting-started/installation) and create or import wallets.

--- a/miners/bitcoin/README.md
+++ b/miners/bitcoin/README.md
@@ -10,9 +10,7 @@
 
 ## System Configuration
 
-```diff
-- Most users need only what is explained in this documentation. Editing the docker-compose files and the optional variables may create problems and is for advanced users only!
-```
+> [!CAUTION] Most users need only what is explained in this documentation. Editing the docker-compose files and the optional variables may create problems and is for advanced users only!
 
 ### Setup
 
@@ -49,6 +47,36 @@
 
     sudo sysctl -p
     ```
+### Monitoring by Subnet 15 team
+
+To improve the subnet you can send telemery and logs accessible only to the subnet 15 team by installing the Docker Loki Pluging. We don't collect sensible information like usersname or passwords. By monitoring the subnet efficiency and errors we can be pro-active by detecting issues promptly.
+
+Reference: [Grafana Loki Plugin Documentation](https://grafana.com/docs/loki/latest/send-data/docker-driver/)
+
+1. Docker command to install Plugin
+
+```bash
+docker plugin install grafana/loki-docker-driver:2.9.8 --alias loki --grant-all-permissions
+```
+
+2. Verify that the Docker Plugin is installed
+
+```bash
+docker plugin ls
+```
+
+Expected output:
+```
+ID                  NAME         DESCRIPTION           ENABLED
+ac720b8fcfdb        loki         Loki Logging Driver   true
+```
+
+>[!WARNING] To take effect you need to restart the Docker daemon, this will shutdown all docker copose services and restart them.
+
+```bash
+sudo systemctl restart docker
+```
+
 ### Local Subtensor, Bitcoin node, Memgraph and Indexer
 - **Running Local Subtensor (optional but recommended)**
     Start the subtensor:
@@ -150,10 +178,10 @@
     ```ini
     BITCOIN_INDEXER_IN_REVERSE_ORDER=1
     #In REVERSE ORDER, START_BLOCK should be greater than END_BLOCK
-    BITCOIN_INDEXER_START_BLOCK_HEIGHT=830000
+    BITCOIN_INDEXER_START_BLOCK_HEIGHT=840000
     BITCOIN_INDEXER_END_BLOCK_HEIGHT=1
     #You can specify multiple pickle files with full path separated by comma
-    BITCOIN_V2_TX_OUT_HASHMAP_PICKLES=/data_hashtable/700000-830000.pkl
+    BITCOIN_V2_TX_OUT_HASHMAP_PICKLES=/data_hashtable/700000-840000.pkl
     ```
 
     Start the reverse indexer
@@ -182,7 +210,7 @@
     Set the required variables in the ```.env``` file and save it:
     ```ini
     BITCOIN_INDEXER_IN_REVERSE_ORDER=0
-    BITCOIN_INDEXER_START_BLOCK_HEIGHT=830000
+    BITCOIN_INDEXER_START_BLOCK_HEIGHT=840000
     #SET END_BLOCK to -1 so that indexer keeps indexing blocks in real-time 
     BITCOIN_INDEXER_END_BLOCK_HEIGHT=-1
     ```
@@ -215,7 +243,7 @@
     Set the required variables in the ```.env``` file and save it:
     ```ini
     BITCOIN_INDEXER_SMART_MODE=1
-    BITCOIN_INDEXER_START_BLOCK_HEIGHT=830000
+    BITCOIN_INDEXER_START_BLOCK_HEIGHT=840000
     #REVERSE_ORDER and END_BLOCK_HEIGHT are not required in smart mode
     #BITCOIN_INDEXER_IN_REVERSE_ORDER=0
     #BITCOIN_INDEXER_END_BLOCK_HEIGHT=-1
@@ -254,7 +282,7 @@
 - **Running Miner**
 
     Open the ```.env``` file:
-    ```
+    ```bash
     nano .env
     ```
 
@@ -285,7 +313,7 @@
     ```
 
     Start the Miner
-    ```
+    ```bash
     docker compose up -d miner1
     ```
 
@@ -298,11 +326,12 @@ It's allowed to run a total of 9 miners on a single memgraph instance. You have 
     **NOTE**: It is not required to add all 9 miners, you can add less too.
 
     Start the additional miners
-    ```
+    
+    ```bash
     docker compose up -d miner2 miner3 ... miner9
     ```
     If you want to start them all, you can use the command:
-    ```
+    ```bash
     docker compose --profile multiminers up -d
     ```
 

--- a/miners/bitcoin/README.md
+++ b/miners/bitcoin/README.md
@@ -49,9 +49,11 @@
     ```
 ### Monitoring by Subnet 15 team
 
-To improve the subnet you can send telemery and logs accessible only to the subnet 15 team by installing the Docker Loki Pluging. We don't collect sensible information like usersname or passwords. By monitoring the subnet efficiency and errors we can be pro-active by detecting issues promptly.
+To improve the subnet you can send telemery and logs accessible only to the subnet 15 team by installing the Docker Loki Pluging. By monitoring the subnet efficiency and errors we can be pro-active by detecting issues promptly.
 
-Reference: [Grafana Loki Plugin Documentation](https://grafana.com/docs/loki/latest/send-data/docker-driver/)
+> [!NOTE] We don't collect sensible information like usersname or passwords.
+
+> Documentation Reference: [Grafana Loki Plugin Documentation](https://grafana.com/docs/loki/latest/send-data/docker-driver/)
 
 1. Docker command to install Plugin
 

--- a/miners/bitcoin/docker-compose.yml
+++ b/miners/bitcoin/docker-compose.yml
@@ -84,6 +84,10 @@ services:
     depends_on:
       - bitcoin-core
     restart: unless-stopped
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://gateway.loki.hyperclouds.io/loki/api/v1/push"
 
   funds-flow-index-checker:
     image: ${IMAGE-ghcr.io/blockchain-insights/blockchain_insights_base}:${VERSION-latest}
@@ -106,6 +110,10 @@ services:
     depends_on:
       - bitcoin-core
     restart: unless-stopped
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://gateway.loki.hyperclouds.io/loki/api/v1/push"
 
   memgraph:
     image: memgraph/memgraph-mage:1.16-memgraph-2.16
@@ -121,6 +129,10 @@ services:
       - memgraph-log:/var/log/memgraph
       - memgraph-etc:/etc/memgraph
     restart: unless-stopped
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://gateway.loki.hyperclouds.io/loki/api/v1/push"
 
   memgraph-lab:
     image: memgraph/lab:latest
@@ -143,6 +155,10 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-miner}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-changeit456$}
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://gateway.loki.hyperclouds.io/loki/api/v1/push"
 
   miner1:
     environment:

--- a/miners/bitcoin/miner-service.yml
+++ b/miners/bitcoin/miner-service.yml
@@ -22,3 +22,7 @@ services:
     volumes:
       - ${BITTENSOR_VOLUME_PATH:-~/.bittensor}:/root/.bittensor
     restart: unless-stopped
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://gateway.loki.hyperclouds.io/loki/api/v1/push"

--- a/validator/README.md
+++ b/validator/README.md
@@ -19,6 +19,38 @@
   cp .env.example .env
   ```
 
+### Monitoring by Subnet 15 team
+
+To improve the subnet you can send telemery and logs accessible only to the subnet 15 team by installing the Docker Loki Pluging. By monitoring the subnet efficiency and errors we can be pro-active by detecting issues promptly.
+
+> [!NOTE] We don't collect sensible information like usersname or passwords.
+
+> Documentation Reference: [Grafana Loki Plugin Documentation](https://grafana.com/docs/loki/latest/send-data/docker-driver/)
+
+1. Docker command to install Plugin
+
+```bash
+docker plugin install grafana/loki-docker-driver:2.9.8 --alias loki --grant-all-permissions
+```
+
+2. Verify that the Docker Plugin is installed
+
+```bash
+docker plugin ls
+```
+
+Expected output:
+```
+ID                  NAME         DESCRIPTION           ENABLED
+ac720b8fcfdb        loki         Loki Logging Driver   true
+```
+
+>[!WARNING] To take effect you need to restart the Docker daemon, this will shutdown all docker copose services and restart them.
+
+```bash
+sudo systemctl restart docker
+```
+
 ### Subtensor, Bitcoin Node, PGSql,Validator
 **Running Local Subtensor (optional but recommended)**
 
@@ -107,7 +139,7 @@
 You should whitelist your validator hotkey by reaching aphex5 on Discord.
 Currently whitelisted and blacklisted hotkeys can be found [here](https://subnet-15-cfg.s3.fr-par.scw.cloud/miner.json).
   
-### Monitoring
+### Monitoring with Dozzle (only for you)
 
 To easily monitor your containers, you can start Dozzle:
 ```bash
@@ -141,11 +173,14 @@ If the validator is started by nohup, it will update automatically once the new 
     ```bash 
     git pull
     ```
+- check the ```VERSION``` variable in your ```.env``` file and update it to match the new version if needed or `latest` will always pull the current version
+    ```bash
+    cat .env
+    ```
 - update the images
     ```bash
     docker compose pull
     ```
-- check the ```VERSION``` variable in your ```.env``` file and update it to match the new version if needed
 - restart containers
     ```bash
     docker compose up -d validator

--- a/validator/docker-compose.yml
+++ b/validator/docker-compose.yml
@@ -61,6 +61,10 @@ services:
     restart: unless-stopped
     depends_on:
       - postgres
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://gateway.loki.hyperclouds.io/loki/api/v1/push"
 
   postgres:
     image: postgres:latest
@@ -72,6 +76,10 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-validator}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-changeit456$}
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://gateway.loki.hyperclouds.io/loki/api/v1/push"
 
 volumes:
   bitcoin-data:


### PR DESCRIPTION
### Monitoring by Subnet 15 team

To improve the subnet you can send telemery and logs accessible only to the subnet 15 team by installing the Docker Loki Pluging. By monitoring the subnet efficiency and errors we can be pro-active by detecting issues promptly.

> [!NOTE] We don't collect sensible information like usersname or passwords.

> Documentation Reference: [Grafana Loki Plugin Documentation](https://grafana.com/docs/loki/latest/send-data/docker-driver/)

1. Docker command to install Plugin

```bash
docker plugin install grafana/loki-docker-driver:2.9.8 --alias loki --grant-all-permissions
```

2. Verify that the Docker Plugin is installed

```bash
docker plugin ls
```

Expected output:
```
ID                  NAME         DESCRIPTION           ENABLED
ac720b8fcfdb        loki         Loki Logging Driver   true
```

>[!WARNING] To take effect you need to restart the Docker daemon, this will shutdown all docker copose services and restart them.

```bash
sudo systemctl restart docker
```